### PR TITLE
named module

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const isBuffer = require('is-buffer');
 const AV = require('av');
 require('mp3');
 
-module.exports = (buffer, opts, cb) => {
+module.exports = function audioDecode(buffer, opts, cb) {
 	if (opts instanceof Function) {
 		cb = opts;
 		opts = {};


### PR DESCRIPTION
I don't like anonymous function especially for module.
because when debugging, console.log( _anonymous function_ ) always shows **[Function (anonymous)]** . 
in other words, console.log( _named function_ ) shows function name like [Function: audioDecode].

If you don't like, throw away this PR.