### PR TITLE
chore: Add a module filed to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.3",
   "description": "Decode audio data in node or browser",
   "main": "audio-decode.js",
+  "module: "audio-decode.js",
   "type": "module",
   "dependencies": {
     "@wasm-audio-decoders/flac": "^0.1.8",


### PR DESCRIPTION
The `module` filed is required by vite.

![CleanShot 2023-07-21 at 08 54 17@2x](https://github.com/audiojs/audio-decode/assets/11806619/b20037ad-4fa5-4ad5-980a-9530601db06d)
