### PR TITLE
Add feature: context-aware creation of audio buffer

### DIFF
--- a/audio-decode.js
+++ b/audio-decode.js
@@ -8,7 +8,7 @@ import AudioBufferShim from 'audio-buffer';
 
 const AudioBuffer = globalThis.AudioBuffer || AudioBufferShim
 
-export default async function audioDecode (buf) {
+export default async function audioDecode (buf, context) {
 	if (!buf && !(buf.length || buf.buffer)) throw Error('Bad decode target')
 	buf = new Uint8Array(buf.buffer || buf)
 
@@ -18,51 +18,60 @@ export default async function audioDecode (buf) {
 
 	if (!decoders[type]) throw Error('Missing decoder for ' + type + ' format')
 
-	return decoders[type](buf)
+	return decoders[type](buf, context)
 };
 
 export const decoders = {
-	async oga(buf) {
+	async oga(buf, context) {
 		let { OggVorbisDecoder } = await import('@wasm-audio-decoders/ogg-vorbis')
 		const decoder = new OggVorbisDecoder()
 		await decoder.ready;
-		return (decoders.oga = async buf => buf && createBuffer(await decoder.decodeFile(buf)))(buf)
+		return (decoders.oga = async buf => buf && createBuffer(await decoder.decodeFile(buf), context))(buf)
 	},
-	async mp3(buf) {
+	async mp3(buf, context) {
 		const { MPEGDecoder } = await import('mpg123-decoder')
 		const decoder = new MPEGDecoder()
 		await decoder.ready;
-		return (decoders.mp3 = buf => buf && createBuffer(decoder.decode(buf)))(buf)
+		return (decoders.mp3 = buf => buf && createBuffer(decoder.decode(buf), context))(buf)
 	},
-	async flac(buf) {
+	async flac(buf, context) {
 		const { FLACDecoder } = await import('@wasm-audio-decoders/flac')
 		const decoder = new FLACDecoder()
 		await decoder.ready;
-		return (decoders.mp3 = async buf => buf && createBuffer(await decoder.decode(buf)))(buf)
+		return (decoders.mp3 = async buf => buf && createBuffer(await decoder.decode(buf), context))(buf)
 	},
-	async opus(buf) {
+	async opus(buf, context) {
 		const { OggOpusDecoder } = await import('ogg-opus-decoder')
 		const decoder = new OggOpusDecoder()
 		await decoder.ready;
-		return (decoders.opus = async buf => buf && createBuffer(await decoder.decodeFile(buf)))(buf)
+		return (decoders.opus = async buf => buf && createBuffer(await decoder.decodeFile(buf), context))(buf)
 	},
-	async wav(buf) {
+	async wav(buf, context) {
 		let module = await import('node-wav')
 		let { decode } = module.default
-		return (decoders.wav = buf => buf && createBuffer(decode(buf)) )(buf)
+		return (decoders.wav = buf => buf && createBuffer(decode(buf), context) )(buf)
 	},
-	async qoa(buf) {
+	async qoa(buf, context) {
 		let { decode } = await import('qoa-format')
-		return (decoders.qoa = buf => buf && createBuffer(decode(buf)) )(buf)
+		return (decoders.qoa = buf => buf && createBuffer(decode(buf), context) )(buf)
 	}
 }
 
-function createBuffer({channelData, sampleRate}) {
-	let audioBuffer = new AudioBuffer({
-		sampleRate,
-		length: channelData[0].length,
-		numberOfChannels: channelData.length
-	})
+function createBuffer({channelData, sampleRate}, context) {
+	let audioBuffer;
+	if (context) {
+		audioBuffer = context.createBuffer(
+			channelData.length,
+			channelData[0].length,
+			sampleRate
+		);
+	} else {
+		audioBuffer = new AudioBuffer({
+			sampleRate,
+			length: channelData[0].length,
+			numberOfChannels: channelData.length
+		})
+	}
 	for (let ch = 0; ch < channelData.length; ch++) audioBuffer.getChannelData(ch).set(channelData[ch])
 	return audioBuffer
 }

--- a/readme.md
+++ b/readme.md
@@ -17,10 +17,10 @@ Supported formats:
 [![npm install audio-decode](https://nodei.co/npm/audio-decode.png?mini=true)](https://npmjs.org/package/audio-decode/)
 
 ```js
-import decodeAudio from 'audio-decode';
+import audioDecode from 'audio-decode';
 import buffer from 'audio-lena/mp3';
 
-let audioBuffer = await decode(buffer);
+let audioBuffer = await audioDecode(buffer);
 ```
 
 `buffer` type can be: _ArrayBuffer_, _Uint8Array_ or _Buffer_.
@@ -30,10 +30,23 @@ Decoder's code is lazy: first run loads decoder's sources and compiles module be
 To get more granular control over individual decoders, use `decoders`:
 
 ```js
-import decode, {decoders} from 'audio-decode';
+import {decoders} from 'audio-decode';
 
 await decoders.mp3(); // load & compile decoder
 const audioBuffer = await decoders.mp3(mp3buf); // decode
+```
+
+## Decode under a specific audio context
+
+Because different audio contexts may use different implementations of the AudioBuffer,
+it is sometimes necessary to decode audio under a specific context.
+This can be done by providing a second argument to `audioDecode`
+to specify the context:
+
+```js
+import audioDecode from 'audio-decode';
+
+let audioBuffer = await audioDecode(buffer, audioContext);
 ```
 
 ## See also


### PR DESCRIPTION
Different audio contexts may use different implementations of AudioBuffer (which may be different from `globalThis.AudioBuffer`). It is necessary to make `audioDecode` able to create audio buffers under a specific context.